### PR TITLE
Feature/admin solution category crud

### DIFF
--- a/Eventy/src/app/app-routing.module.ts
+++ b/Eventy/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import {CreateEventTypeComponent} from './events/create-event-type/create-event-
 import {EditEventTypeComponent} from './events/edit-event-type/edit-event-type.component';
 import { EditServiceComponent } from './services/edit-service/edit-service.component';
 import { MyServicesViewComponent } from './services/my-services-view/my-services-view.component';
+import { SolutionCategoryManagementComponent } from './solutions/solution-category-management/solution-category-management.component';
 
 const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -22,6 +23,7 @@ const routes: Routes = [
   {path: 'edit-event-type/:id', component: EditEventTypeComponent},
   {path: 'edit-service/:id', component: EditServiceComponent},
   {path: 'my-services', component: MyServicesViewComponent},
+  {path: 'solution-categories', component: SolutionCategoryManagementComponent},
   {path: '**', redirectTo: ''},
 ];
 

--- a/Eventy/src/app/app.module.ts
+++ b/Eventy/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {EventsModule} from './events/events.module';
 import { SolutionsModule } from './solutions/solutions.module';
 import { ProductsModule } from './products/products.module';
 import { ServicesModule } from './services/services.module';
+import { provideHttpClient } from '@angular/common/http';
 
 @NgModule({
   declarations: [
@@ -29,7 +30,8 @@ import { ServicesModule } from './services/services.module';
   ],
   providers: [
     provideAnimationsAsync(),
-    { provide: LOCALE_ID, useValue: 'en-GB' }
+    { provide: LOCALE_ID, useValue: 'en-GB' },
+    provideHttpClient(),
   ],
   bootstrap: [AppComponent]
 })

--- a/Eventy/src/app/layout/nav-drawer/nav-drawer.component.html
+++ b/Eventy/src/app/layout/nav-drawer/nav-drawer.component.html
@@ -8,7 +8,7 @@
   <a class="sidenav-link" [routerLink]="['organize-event']" (click)="drawer.toggle()"><mat-icon>event_note</mat-icon> Organize Event</a>
   <a class="sidenav-link" [routerLink]="['add-service']" (click)="drawer.toggle()"><mat-icon>face</mat-icon> Add Service</a>
   <a class="sidenav-link" [routerLink]="['event-types']" (click)="drawer.toggle()"><mat-icon>theater_comedy</mat-icon> Event Types</a>
-  <a class="sidenav-link" [routerLink]="['my-services']" (click)="drawer.toggle()"><mat-icon>sentiment_very_satisfied
-  </mat-icon> My services</a>
+  <a class="sidenav-link" [routerLink]="['my-services']" (click)="drawer.toggle()"><mat-icon>sentiment_very_satisfied</mat-icon> My services</a>
+  <a class="sidenav-link" [routerLink]="['solution-categories']" (click)="drawer.toggle()"><mat-icon>hardware</mat-icon> Solution categories</a>
 </mat-nav-list>
 

--- a/Eventy/src/app/shared/shared.module.ts
+++ b/Eventy/src/app/shared/shared.module.ts
@@ -2,16 +2,22 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {InvalidInputDataDialogComponent} from './invalid-input-data-dialog/invalid-input-data-dialog.component';
 import {MaterialModule} from '../infrastructure/material/material.module';
+import { SolutionCategoryInputDialogComponent } from './solution-category-input-dialog/solution-category-input-dialog.component';
+import { FormsModule } from '@angular/forms';
+import { YesNoInputDialogComponent } from './yes-no-input-dialog/yes-no-input-dialog.component';
 
 
 
 @NgModule({
   declarations: [
-    InvalidInputDataDialogComponent
+    InvalidInputDataDialogComponent,
+    SolutionCategoryInputDialogComponent,
+    YesNoInputDialogComponent
   ],
   imports: [
     CommonModule,
-    MaterialModule
+    MaterialModule,
+    FormsModule
   ],
   exports: [InvalidInputDataDialogComponent]
 })

--- a/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.css
+++ b/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.css
@@ -1,0 +1,4 @@
+mat-dialog-content {
+    display: flex;
+    flex-direction: column;
+}

--- a/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.html
+++ b/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.html
@@ -1,0 +1,13 @@
+<h2 mat-dialog-title>{{message}}</h2>
+<mat-dialog-content>
+  <mat-form-field>
+    <input matInput [(ngModel)]="categoryName" placeholder="Enter category name" />
+  </mat-form-field>
+  <mat-form-field>
+    <input matInput [(ngModel)]="categoryDescription" placeholder="Enter category description" />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button (click)="saveInput()">OK</button>
+  <button mat-button (click)="closeDialog()">Cancel</button>
+</mat-dialog-actions>

--- a/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.spec.ts
+++ b/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SolutionCategoryInputDialogComponent } from './solution-category-input-dialog.component';
+
+describe('SolutionCategoryInputDialogComponent', () => {
+  let component: SolutionCategoryInputDialogComponent;
+  let fixture: ComponentFixture<SolutionCategoryInputDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SolutionCategoryInputDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SolutionCategoryInputDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.ts
+++ b/Eventy/src/app/shared/solution-category-input-dialog/solution-category-input-dialog.component.ts
@@ -1,0 +1,49 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Status } from '../../solutions/model/category.model';
+import { CategoryWithId } from '../../solutions/model/category-with-id.model';
+import { SolutionCategoryService } from '../../solutions/services/solutions/solution-category.service';
+
+interface SolutionCategoryInputDialogData {
+  message: string;
+  categoryId: number;
+  categoryName: string;
+  categoryDescription: string;
+  categoryStatus: Status;
+}
+
+@Component({
+  selector: 'app-solution-category-input-dialog',
+  templateUrl: './solution-category-input-dialog.component.html',
+  styleUrl: './solution-category-input-dialog.component.css'
+})
+export class SolutionCategoryInputDialogComponent {
+  message: string = ''
+  categoryId: number = null;
+  categoryName: string = '';
+  categoryDescription: string = '';
+  categoryStatus: Status = Status.PENDING;
+
+  constructor(public dialogRef: MatDialogRef<SolutionCategoryInputDialogComponent>, @Inject(MAT_DIALOG_DATA) public data: SolutionCategoryInputDialogData, private categoriesService: SolutionCategoryService) {
+    this.categoryId = data.categoryId;
+    this.categoryName = data.categoryName;
+    this.categoryDescription = data.categoryDescription;
+    this.categoryStatus = data.categoryStatus;
+    this.message = data.message;  
+  }
+
+  closeDialog(): void {
+    this.dialogRef.close([false, null]);
+  }
+
+  saveInput(): void {
+    let updatedCategory: CategoryWithId = {
+      id: this.categoryId,
+      name: this.categoryName,
+      description: this.categoryDescription,
+      status: this.categoryStatus
+    };
+    this.dialogRef.close([true, updatedCategory])
+  }
+
+}

--- a/Eventy/src/app/shared/yes-no-input-dialog/yes-no-input-dialog.component.html
+++ b/Eventy/src/app/shared/yes-no-input-dialog/yes-no-input-dialog.component.html
@@ -1,0 +1,5 @@
+<h2 mat-dialog-title><b>{{message}}</b></h2>
+<mat-dialog-actions>
+    <button mat-button (click)="onYes()">Yes</button>
+    <button mat-button (click)="onNo()">No</button>
+</mat-dialog-actions>

--- a/Eventy/src/app/shared/yes-no-input-dialog/yes-no-input-dialog.component.spec.ts
+++ b/Eventy/src/app/shared/yes-no-input-dialog/yes-no-input-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { YesNoInputDialogComponent } from './yes-no-input-dialog.component';
+
+describe('YesNoInputDialogComponent', () => {
+  let component: YesNoInputDialogComponent;
+  let fixture: ComponentFixture<YesNoInputDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [YesNoInputDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(YesNoInputDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Eventy/src/app/shared/yes-no-input-dialog/yes-no-input-dialog.component.ts
+++ b/Eventy/src/app/shared/yes-no-input-dialog/yes-no-input-dialog.component.ts
@@ -1,0 +1,28 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+interface YesNoInputDialogData {
+  message: string
+}
+
+@Component({
+  selector: 'app-yes-no-input-dialog',
+  templateUrl: './yes-no-input-dialog.component.html',
+  styleUrl: './yes-no-input-dialog.component.css'
+})
+export class YesNoInputDialogComponent {
+
+  message: string
+
+  constructor(private dialogRef: MatDialogRef<YesNoInputDialogComponent>, @Inject(MAT_DIALOG_DATA) public data: YesNoInputDialogData) {
+    this.message = data.message;
+  }
+
+  onYes() {
+    this.dialogRef.close(true);
+  }
+
+  onNo() {
+    this.dialogRef.close(false);
+  }
+}

--- a/Eventy/src/app/solutions/model/category-with-id.model.ts
+++ b/Eventy/src/app/solutions/model/category-with-id.model.ts
@@ -1,0 +1,5 @@
+import { Category } from "./category.model";
+
+export interface CategoryWithId extends Category {
+    id: number
+}

--- a/Eventy/src/app/solutions/services/solutions/solution-category.service.spec.ts
+++ b/Eventy/src/app/solutions/services/solutions/solution-category.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SolutionCategoryService } from './solution-category.service';
+
+describe('SolutionCategoryService', () => {
+  let service: SolutionCategoryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SolutionCategoryService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Eventy/src/app/solutions/services/solutions/solution-category.service.ts
+++ b/Eventy/src/app/solutions/services/solutions/solution-category.service.ts
@@ -1,0 +1,44 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { environment } from '../../../../env/constants';
+import { CategoryWithId } from '../../model/category-with-id.model';
+import { Category, Status } from '../../model/category.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SolutionCategoryService {
+  private controllerURL: string = environment.apiHost + "/api/categories";
+  categories: CategoryWithId[] = [
+    { id: 1, name: 'Category 1', description: 'Description for category 1', status: Status.ACCEPTED },
+    { id: 2, name: 'Category 2', description: 'Description for category 2', status: Status.ACCEPTED },
+    { id: 3, name: 'Category 3', description: 'Description for category 3', status: Status.ACCEPTED },
+    { id: 4, name: 'Category 4', description: 'Description for category 4', status: Status.ACCEPTED },
+    { id: 5, name: 'Category 5', description: 'Description for category 5', status: Status.ACCEPTED },
+    { id: 6, name: 'Category 6', description: 'Description for category 6', status: Status.ACCEPTED },
+    { id: 7, name: 'Category 7', description: 'Description for category 7', status: Status.ACCEPTED },
+    { id: 8, name: 'Category 8', description: 'Description for category 8', status: Status.ACCEPTED },
+    { id: 9, name: 'Category 9', description: 'Description for category 9', status: Status.ACCEPTED },
+    { id: 10, name: 'Category 10', description: 'Description for category 10', status: Status.ACCEPTED }
+ ];
+
+  constructor(private httpClient: HttpClient) { }
+
+  getAll(): Observable<CategoryWithId[]> {
+    //return this.httpClient.get<CategoryWithId[]>(this.controllerURL)
+    return of(this.categories)
+  }
+
+  delete(categoryId: number): void {
+    this.httpClient.delete(this.controllerURL + categoryId);
+  }
+
+  update(category: CategoryWithId): Observable<CategoryWithId> {
+    return this.httpClient.put<CategoryWithId>(this.controllerURL + `/${category.id}`, category);
+  }
+
+  create(category: Category): Observable<CategoryWithId> {
+    return this.httpClient.post<CategoryWithId>(this.controllerURL, category)
+  }
+}

--- a/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.css
+++ b/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.css
@@ -1,0 +1,35 @@
+.container {
+    background-color: #F1F1F1;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+}
+
+mat-card {
+    width: 47%;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+mat-card-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.manipulation_buttons_container {
+    display: inline;
+}
+
+.edit-btn {
+    color: white !important;
+    background-color: blue !important;
+    text-align: right;
+    margin-right: 10px
+}
+
+.delete-btn {
+    color: white !important;
+    background-color: red !important;
+    text-align: right;
+}

--- a/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.html
+++ b/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.html
@@ -1,0 +1,31 @@
+<div class="container">
+    <mat-card>
+        <mat-card-content>
+            <b>{{categoryDouble[0].name}}</b>
+            <div class = "manipulation_buttons_container">
+                <a mat-button class="edit-btn" (click)="editCategory(categoryDouble[0], 0)">
+                  <mat-icon>edit</mat-icon> Edit
+                </a>
+                <a mat-button class="delete-btn" (click)="deleteCategory(categoryDouble[0])">
+                  <mat-icon>delete</mat-icon> Delete
+                </a>
+            </div>
+        </mat-card-content>
+    </mat-card>
+
+    <mat-card *ngIf="categoryDouble[1]">
+        <mat-card-content>
+            <b>{{categoryDouble[1].name}}</b>
+            <div class = "manipulation_buttons_container">
+                <a mat-button class="edit-btn" (click)="editCategory(categoryDouble[1], 1)">
+                  <mat-icon>edit</mat-icon> Edit
+                </a>
+                <a mat-button class="delete-btn" (click)="deleteCategory(categoryDouble[1])">
+                  <mat-icon>delete</mat-icon> Delete
+                </a>
+            </div>
+        </mat-card-content>
+    </mat-card>
+
+    
+</div>

--- a/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.spec.ts
+++ b/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SolutionCategoriesViewDualCardComponent } from './solution-categories-view-dual-card.component';
+
+describe('SolutionCategoriesViewDualCardComponent', () => {
+  let component: SolutionCategoriesViewDualCardComponent;
+  let fixture: ComponentFixture<SolutionCategoriesViewDualCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SolutionCategoriesViewDualCardComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SolutionCategoriesViewDualCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.ts
+++ b/Eventy/src/app/solutions/solution-categories-view-dual-card/solution-categories-view-dual-card.component.ts
@@ -1,0 +1,65 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { SolutionCategoryInputDialogComponent } from '../../shared/solution-category-input-dialog/solution-category-input-dialog.component';
+import { MatDialog } from '@angular/material/dialog';
+import { CategoryWithId } from '../model/category-with-id.model';
+import { SolutionCategoryService } from '../services/solutions/solution-category.service';
+import { YesNoInputDialogComponent } from '../../shared/yes-no-input-dialog/yes-no-input-dialog.component';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-solution-categories-view-dual-card',
+  templateUrl: './solution-categories-view-dual-card.component.html',
+  styleUrl: './solution-categories-view-dual-card.component.css'
+})
+export class SolutionCategoriesViewDualCardComponent {
+  @Input()
+  categoryDouble: CategoryWithId[];
+  
+  @Output()
+  categoryDeleted: EventEmitter<CategoryWithId> = new EventEmitter<CategoryWithId>();
+
+  @Output()
+  categoryEdited: EventEmitter<CategoryWithId> = new EventEmitter<CategoryWithId>();
+
+  constructor(private editDialog: MatDialog, private deleteDialog: MatDialog, private categoriesService: SolutionCategoryService) {
+
+  }
+
+  editCategory(category: CategoryWithId, cardIndex: number) {
+    let dialogRef = this.editDialog.open(SolutionCategoryInputDialogComponent, {
+      data: {
+        message: `Edit category: ${category.name}`,
+        categoryId: category.id,
+        categoryName: category.name,
+        categoryDescription: category.description,
+        categoryStatus: category.status
+      }
+    })
+
+    dialogRef.afterClosed().subscribe(returnValues => {
+      if (returnValues[0]) {
+        //let updatedEntity: Observable<CategoryWithId> = this.categoriesService.update(returnValues[1])
+        //TODO: Uncomment later once backend is implemented
+        let updatedEntity: Observable<CategoryWithId> = new Observable(observer => {observer.next(returnValues[1]); observer.complete()});
+        updatedEntity.subscribe((updatedEntityValue: CategoryWithId) => {
+          this.categoryDouble[cardIndex] = updatedEntityValue;
+          this.categoryEdited.emit(updatedEntityValue);
+        })
+      }
+    })
+  }
+
+  deleteCategory(category: CategoryWithId) {
+    let dialogRef = this.deleteDialog.open(YesNoInputDialogComponent, {
+      data: { message: `Are you sure you want to delete the category ${category.name}?`}
+    });
+
+    dialogRef.afterClosed().subscribe(doDelete => {
+      if (doDelete) {
+        this.categoriesService.delete(category.id);
+        this.categoryDeleted.emit(category)
+      }
+    })
+
+  }
+}

--- a/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.css
+++ b/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.css
@@ -1,0 +1,15 @@
+mat-paginator {
+    background-color: #F1F1F1;
+}
+
+button {
+    background-color: #07FC03; 
+    color: white !important;
+    margin-bottom: 10px;
+}
+
+.button-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}

--- a/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.html
+++ b/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.html
@@ -1,0 +1,10 @@
+<div *ngFor="let categoryPair of categoryPairs">
+    <app-solution-categories-view-dual-card [categoryDouble]="categoryPair" (categoryDeleted)="categoryDeleted($event)" (categoryEdited)="categoryEdited($event)"></app-solution-categories-view-dual-card>
+</div>
+<mat-paginator [length]="categories.length" [pageSize]="10" (page)="onPageChange($event)" [pageSizeOptions]="[6, 10, 20]" aria-label="Select page">
+</mat-paginator>
+<div class="button-container">
+    <button mat-button (click)="addCategory()">
+        <mat-icon>add</mat-icon> Add new category
+    </button>
+</div>

--- a/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.spec.ts
+++ b/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SolutionCategoriesViewComponent } from './solution-categories-view.component';
+
+describe('SolutionCategoriesViewComponent', () => {
+  let component: SolutionCategoriesViewComponent;
+  let fixture: ComponentFixture<SolutionCategoriesViewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SolutionCategoriesViewComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SolutionCategoriesViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.ts
+++ b/Eventy/src/app/solutions/solution-categories-view/solution-categories-view.component.ts
@@ -1,0 +1,95 @@
+import { Component } from '@angular/core';
+import { Status } from '../model/category.model';
+import { SolutionCategoryService } from '../services/solutions/solution-category.service';
+import { Observable } from 'rxjs';
+import { CategoryWithId } from '../model/category-with-id.model';
+import { PageEvent } from '@angular/material/paginator';
+import { MatDialog } from '@angular/material/dialog';
+import { SolutionCategoryInputDialogComponent } from '../../shared/solution-category-input-dialog/solution-category-input-dialog.component';
+
+@Component({
+  selector: 'app-solution-categories-view',
+  templateUrl: './solution-categories-view.component.html',
+  styleUrl: './solution-categories-view.component.css'
+})
+export class SolutionCategoriesViewComponent {
+  categories: CategoryWithId[] = [];
+
+ paginatedCategories: CategoryWithId[];
+ categoryPairs: CategoryWithId[][] = []
+ private pageSize: number;
+ private currentPage: number;
+  constructor(private creationDialog: MatDialog, private categoryService: SolutionCategoryService) {
+    this.updatePaginatedCategories();
+  }
+
+  ngOnInit(): void {
+    this.pageSize = 10;
+    this.currentPage = 0;
+    this.getAll();
+    this.updatePaginatedCategories();
+  }
+
+  getAll(): void {
+    this.categoryService.getAll().subscribe({
+      next: (category: CategoryWithId[]) => {
+        this.categories = category;
+      }
+    })
+  }
+
+  onPageChange(event: PageEvent): void {
+    this.pageSize = event.pageSize;
+    this.currentPage = event.pageIndex;
+    this.updatePaginatedCategories();
+  }
+
+  private updatePaginatedCategories(): void {
+    const startIndex = this.currentPage * this.pageSize;
+    const endIndex = startIndex + this.pageSize;
+    this.paginatedCategories = this.categories.slice(startIndex, endIndex);
+    this.categoryPairs = []
+    for (let i = 0; i < this.paginatedCategories.length / 2; i++) {
+      this.categoryPairs.push([this.paginatedCategories[i*2], this.paginatedCategories[i*2 + 1]])
+    }
+  }
+
+  addCategory() {
+    let dialogRef = this.creationDialog.open(SolutionCategoryInputDialogComponent, {
+      data: {
+        message: "Create new category",
+        categoryName: '',
+        categoryDescription: '',
+        categoryStatus: Status.ACCEPTED
+      }
+    })
+
+    dialogRef.afterClosed().subscribe(returnValues => {
+      if (returnValues[0]) {
+        //let updatedEntity: Observable<CategoryWithId> = this.categoriesService.create(returnValues[1])
+        //TODO: Uncomment later once backend is implemented
+        let createdEntity: Observable<CategoryWithId> = new Observable(observer => {observer.next(returnValues[1]); observer.complete()});
+        createdEntity.subscribe((createdEntityValue: CategoryWithId) => {
+            this.categoryService.create(createdEntityValue)
+            this.categories.push(createdEntityValue)
+        })
+      }
+    })
+  }
+
+  categoryDeleted(category: CategoryWithId) {
+    let index: number = this.categories.indexOf(category);
+    if (index > -1) {
+      this.categories.splice(index, 1);
+    }
+    this.updatePaginatedCategories();
+  }
+
+  categoryEdited(category: CategoryWithId) {
+    let index: number = this.categories.findIndex(v => category.id === v.id)
+    if (index > -1) {
+      this.categories[index] = category;
+    }
+    this.updatePaginatedCategories();
+  }
+}

--- a/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.css
+++ b/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.css
@@ -1,0 +1,78 @@
+.tabs_container {
+    display: flex;
+    flex: 1;
+    flex-direction: row;
+    height: 60px;
+    justify-content: center;
+    align-items: center;
+    background-color: #F7F7F7;
+ }
+ 
+    .categories_tab_container {
+       display: flex;
+       position: relative;
+       flex: 1;
+       height: 38px;
+       margin-left: 30px;
+       margin-right: 15px;
+       background-color: #ffffff;
+       border: solid 2px #929AB7;
+       border-radius: 10px;
+       justify-content: center;
+       align-items: center;
+       align-content: center;   
+       cursor: pointer; 
+    } 
+ 
+       .categories_tab_left_border {
+          position: absolute;
+          left: 0;
+          background-color: #929AB7;
+          height: 38px;
+          border-top-left-radius: 10px;
+          border-bottom-left-radius: 10px;
+          margin-left: -2px;
+          width: 20px;
+       }
+ 
+    .requests_tab_container {
+       display: flex;
+       position: relative;
+       flex: 1;
+       height: 38px;
+       margin-left: 15px;
+       margin-right: 30px;
+       background-color: #ffffff;
+       border: solid 2px #929AB7;
+       border-radius: 10px;
+       justify-content: center;
+       align-items: center;
+       align-content: center;
+       cursor: pointer;
+    } 
+ 
+       .requests_tab_left_border {
+          position: absolute;
+          left: 0;
+          background-color: #929AB7;
+          height: 38px;
+          border-top-left-radius: 10px;
+          border-bottom-left-radius: 10px;
+          margin-left: -2px;
+          width: 20px;
+       }
+ 
+ 
+      .tab_name {
+         height: 11px;
+         font-size: 16px;
+         margin-left: 7px;
+         font-family: "Albert Sans";
+         font-weight: 700;
+         color: #6E717B;
+      }
+
+.main_content_container {
+   background-color: #F1F1F1;
+   width: 100%;
+}

--- a/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.html
+++ b/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.html
@@ -1,0 +1,27 @@
+<div class = "tabs_container">
+
+    <div (click)="switchTab(1)" class = "categories_tab_container" [ngStyle]="{'opacity' : isRequestsSelected ? '100%' : '35%'}">
+        <div *ngIf="isRequestsSelected" class = "categories_tab_left_border"></div>
+        <p class = "tab_name"> Existing categories </p>
+    </div>
+ 
+    <div (click)="switchTab(2)" class = "requests_tab_container" [ngStyle]="{'opacity' : !isRequestsSelected ? '100%' : '35%'}"> 
+        <div *ngIf="!isRequestsSelected" class = "requests_tab_left_border"></div> 
+        <p class = "tab_name"> Requests </p>
+    </div>
+</div>
+
+<div class="main_content_container">
+    <div *ngIf="isRequestsSelected">
+    <app-solution-categories-view></app-solution-categories-view>
+    </div>
+
+    <div *ngIf="!isRequestsSelected">
+    
+    </div>
+</div>
+
+<div *ngIf="isRequestsSelected" class="buttons_container">
+    
+</div>
+ 

--- a/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.spec.ts
+++ b/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SolutionCategoryManagementComponent } from './solution-category-management.component';
+
+describe('SolutionCategoryManagementComponent', () => {
+  let component: SolutionCategoryManagementComponent;
+  let fixture: ComponentFixture<SolutionCategoryManagementComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SolutionCategoryManagementComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SolutionCategoryManagementComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.ts
+++ b/Eventy/src/app/solutions/solution-category-management/solution-category-management.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-solution-category-management',
+  templateUrl: './solution-category-management.component.html',
+  styleUrl: './solution-category-management.component.css'
+})
+export class SolutionCategoryManagementComponent {
+  isRequestsSelected: boolean = true;
+  currentTab: number = 1;
+
+  switchTab(tab: number) : void { 
+    if (this.currentTab === 1 && tab === 2) {
+      this.currentTab = 2;
+      this.isRequestsSelected = !this.isRequestsSelected;
+    }
+
+    if (this.currentTab === 2 && tab === 1) {
+      this.currentTab = 1;
+      this.isRequestsSelected = !this.isRequestsSelected;
+    }
+  }
+}

--- a/Eventy/src/app/solutions/solutions.module.ts
+++ b/Eventy/src/app/solutions/solutions.module.ts
@@ -17,6 +17,11 @@ import { ServicesModule } from '../services/services.module';
 import { ProductsModule } from '../products/products.module';
 import { FeaturedSolutionsComponent } from './featured-solutions/featured-solutions.component';
 import { FormsModule } from '@angular/forms';
+import { SolutionCategoryManagementComponent } from './solution-category-management/solution-category-management.component';
+import { SolutionCategoriesViewComponent } from './solution-categories-view/solution-categories-view.component';
+import { MatCardModule } from '@angular/material/card';
+import { SolutionCategoriesViewDualCardComponent } from './solution-categories-view-dual-card/solution-categories-view-dual-card.component';
+import { SharedModule } from '../shared/shared.module';
 
 
 @NgModule({
@@ -24,6 +29,9 @@ import { FormsModule } from '@angular/forms';
     SolutionFiltersComponent,
     AllSolutionsComponent,
     FeaturedSolutionsComponent,
+    SolutionCategoryManagementComponent,
+    SolutionCategoriesViewComponent,
+    SolutionCategoriesViewDualCardComponent,
   ],
   imports: [
     CommonModule,
@@ -40,7 +48,8 @@ import { FormsModule } from '@angular/forms';
     ServicesModule,
     ProductsModule,
     FormsModule,
-    
+    MatCardModule,
+    SharedModule,
 ],
   exports: [
     SolutionFiltersComponent,

--- a/Eventy/src/env/constants.ts
+++ b/Eventy/src/env/constants.ts
@@ -1,0 +1,3 @@
+export const environment = {
+    apiHost: 'http://localhost:8080',
+};


### PR DESCRIPTION
Hello colleague!

I come to you with the following additions:

- Added the solution category management page for administrators. It comes with working CRUD
- Added the solution category service. It currently returns stub values for its getAll method, but it has implemented REST calls
- Added the variable for our API Host (localhost:8080), and added the provider for the HttpClient needed to communicate with our backend
- Added a dialog that can be used for category-related functions, with a customizable title
- Added a Yes/No dialog, with a customizable title

Currently, authorization checks are missing. I will add them in due time.

There was a conflict with the dev branch - we both added things to the app-routing module. I've merged the dev branch and resolved it.

This PR is not high priority, so you can take your time with going over it. Let me know what you think!